### PR TITLE
Check waiting status when updating module status

### DIFF
--- a/src/main/java/org/platypus/mvnWatcher/model/MvnBuildStatus.groovy
+++ b/src/main/java/org/platypus/mvnWatcher/model/MvnBuildStatus.groovy
@@ -44,7 +44,8 @@ class MvnBuildStatus {
 	 * @param moduleName the name of the module currently being built
 	 */
 	public void setBuildingModule(String moduleName){
-		int index = modulesStatus.findIndexOf{it.moduleName == moduleName}
+		// check also for waiting status to avoid duplicates
+		int index = modulesStatus.findIndexOf{it.moduleName == moduleName && it.waiting}
 		switch(index){
 			case -1:
 			// module is not yet included -> include as Building


### PR DESCRIPTION
Now when looking for the module to update its status, it is looked for
by name and waiting status to solve the issue with the duplicates.

Closes #15
